### PR TITLE
ignore ami changes to prevent ec2 instance replacement

### DIFF
--- a/modules/ec2-sgw/main.tf
+++ b/modules/ec2-sgw/main.tf
@@ -35,6 +35,7 @@ resource "aws_instance" "ec2_sgw" {
       condition     = var.create_security_group || try((length(var.security_group_id) > 3 && substr(var.security_group_id, 0, 3) == "sg-"), false)
       error_message = "Please specify create_security_group = true or provide a valid Security Group ID for var.security_group_id"
     }
+    ignore_changes = [ami]
   }
 }
 


### PR DESCRIPTION
Ignore `ami` changes to prevent the EC2 instance to be replaced when a newer AMI is released. This will break the whole setup as the Storage Gateway (`aws-sgw`) is not updated and will go into an `offline` state. This cannot be recovered with Terraform as the Storage Gateway is in a failed state. It's also not required to update the instance directly as the Storage Gateway service will update the installation.

<img width="1003" alt="Screenshot 2024-07-04 at 12 01 07" src="https://github.com/aws-ia/terraform-aws-storagegateway/assets/97663462/5cb195b7-0803-469b-98d2-70878050ccd2">

<img width="1339" alt="Screenshot 2024-07-04 at 12 00 23" src="https://github.com/aws-ia/terraform-aws-storagegateway/assets/97663462/31d3c81e-5e1a-4519-ae73-6aef6164f0d1">
